### PR TITLE
Fix potential error if BlueMapAPI is enabled already before BlueMapDeathMarkers is loading

### DIFF
--- a/src/main/java/com/technicjelle/bluemapdeathmarkers/BlueMapDeathMarkers.java
+++ b/src/main/java/com/technicjelle/bluemapdeathmarkers/BlueMapDeathMarkers.java
@@ -49,10 +49,10 @@ public final class BlueMapDeathMarkers extends JavaPlugin implements Listener {
 	public void onEnable() {
 		new Metrics(this, 18983);
 
-		BlueMapAPI.onEnable(onEnable);
-
 		updateChecker = new UpdateChecker("TechnicJelle", "BlueMapDeathMarkers", getDescription().getVersion());
 		updateChecker.checkAsync();
+
+		BlueMapAPI.onEnable(onEnable);
 
 		getServer().getPluginManager().registerEvents(this, this);
 	}


### PR DESCRIPTION
This **should** fix an error if BlueMapAPI is enabled already before BlueMapDeathMarkers is loading ^^
(untested :p)

https://discord.com/channels/665868367416131594/863844716047106068/1177883561932623893
```
java.lang.NullPointerException: Cannot invoke "com.technicjelle.UpdateChecker.logUpdateMessage(java.util.logging.Logger)" because "this.updateChecker" is null
    at BlueMapDeathMarkers-1.2(1).jar//com.technicjelle.bluemapdeathmarkers.BlueMapDeathMarkers.lambda$new$0(BlueMapDeathMarkers.java:61)
    at BlueMap-3.18-5-paper.jar//de.bluecolored.bluemap.api.BlueMapAPI.registerInstance(BlueMapAPI.java:211)
    at BlueMap-3.18-5-paper.jar//de.bluecolored.bluemap.common.api.BlueMapAPIImpl.register(BlueMapAPIImpl.java:175)
    at BlueMap-3.18-5-paper.jar//de.bluecolored.bluemap.common.plugin.Plugin.load(Plugin.java:351)
    at BlueMap-3.18-5-paper.jar//de.bluecolored.bluemap.common.plugin.Plugin.load(Plugin.java:112)
    at BlueMap-3.18-5-paper.jar//de.bluecolored.bluemap.common.plugin.Plugin.reload(Plugin.java:465)
    at BlueMap-3.18-5-paper.jar//de.bluecolored.bluemap.common.plugin.commands.Commands.lambda$reloadCommand$5(Commands.java:398)
    at java.base/java.lang.Thread.run(Unknown Source)
```